### PR TITLE
Switch to release build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 prebuilds/
 h3/
 yarn.lock
+package-lock.json

--- a/.prebuild.sh
+++ b/.prebuild.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
 
 set -vex;
+
+COMMON_CMAKE_ARGS=-DCMAKE_BUILD_TYPE=Release
+
 npm run clean &&
   git clone https://github.com/uber/h3 &&
   cd h3 &&
   git checkout v3.6.2 &&
   if command -v make; then
     if [[ "${ARCH}" == "ia32" ]]; then
-      cmake . -DCMAKE_C_FLAGS="-fPIC -m32" && make h3;
+      cmake . ${COMMON_CMAKE_ARGS} -DCMAKE_C_FLAGS="-fPIC -m32";
     else
-      cmake . -DCMAKE_C_FLAGS=-fPIC && make h3;
+      cmake . ${COMMON_CMAKE_ARGS} -DCMAKE_C_FLAGS=-fPIC;
     fi
   else
     if [[ "${Platform}" == "x64" ]]; then
-      cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+      cmake . ${COMMON_CMAKE_ARGS} -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64";
     else
-      cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+      cmake . ${COMMON_CMAKE_ARGS} -DCMAKE_VS_PLATFORM_NAME=${Platform};
     fi
   fi &&
+  cmake --build . --target h3 --config Release &&
   cd .. &&
   prebuildify --target=node@`node --version | sed s/v//`
 


### PR DESCRIPTION
This was brought to mind thanks to helium/erlang-h3#12. Main change is to switch to switch to using the release configuration; other changes that are included are to ignore `package-lock.json` just as `yarn.lock`, and to have CMake invoke the build tool (I think there's a way you can avoid hard coding `"Visual Studio 14 Win64"` which was applied to h3-java but it's not critical right now.)